### PR TITLE
Allow multiline strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,15 +151,19 @@ and automatic filetype detection for `*.tpl` files.
 
 Haskell actually supports multi-line strings by escaping the newline, but I
 don't think it's a widely used feature and I think quasi quoting is better
-for such purposes.  Thus I have opted to keep string literals from crossing
-lines so half your source file doesn't highlight as a string while you're
-entering one, and instead, string literals without a matching end quote
+for such purposes.  Thus, by default, I have opted to keep string literals from
+crossing lines so half your source file doesn't highlight as a string while
+you're entering one. Instead, string literals without a matching end quote
 highlight as errors.
 
 ![Strings screenshot](https://github.com/dag/vim2hs/raw/master/screenshots/strings.png)
 
-There are currently no configuration options for this, but I might add one
-in the future if anyone is actually using the escaped newline syntax.
+There is a configuration option for this. To enable multi-line strings, use
+this:
+
+```vim
+:let g:haskell_multiline_strings = 1
+```
 
 ### HLint
 

--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -142,15 +142,26 @@ function! vim2hs#haskell#syntax#strings() " {{{
     \ "^'\%([^\\]\|\\[^']\+\|\\'\)'"
     \ contains=hsSpecialChar,hsSpecialCharError
 
-  syntax region hsStringError
-    \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
-    \ contains=hsSpecialChar,@Spell
+  if exists('g:haskell_multiline_strings') && g:haskell_multiline_strings
+      syntax match hsLineContinuation
+        \ "\%(\\$\|^\s*\\\)"
+        \ contained
 
-  syntax region hsString
-    \ start=+"+ skip=+\\\\\|\\"+ end=+"+
-    \ oneline contains=hsSpecialChar,@Spell
+      syntax region hsString
+        \ start=+"+ skip=+\\\\\|\\"+ end=+"+
+        \ contains=hsSpecialChar,@Spell,hsLineContinuation
+  else
+      syntax region hsStringError
+        \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
+        \ contains=hsSpecialChar,@Spell
+
+      syntax region hsString
+        \ start=+"+ skip=+\\\\\|\\"+ end=+"+
+        \ oneline contains=hsSpecialChar,@Spell
+  endif
 
   highlight! link hsSpecialChar SpecialChar
+  highlight! link hsLineContinuation SpecialChar
   highlight! link hsSpecialCharError Error
   highlight! link hsCharacter Character
   highlight! link hsStringError Error

--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -115,7 +115,7 @@ function! vim2hs#haskell#syntax#folds() " {{{
 endfunction " }}}
 
 
-function! vim2hs#haskell#syntax#strings() " {{{
+function! vim2hs#haskell#syntax#strings(multiline_strings) " {{{
   syntax match hsSpecialChar
     \ contained
     \ "\\\%([0-9]\+\|o[0-7]\+\|
@@ -142,7 +142,7 @@ function! vim2hs#haskell#syntax#strings() " {{{
     \ "^'\%([^\\]\|\\[^']\+\|\\'\)'"
     \ contains=hsSpecialChar,hsSpecialCharError
 
-  if exists('g:haskell_multiline_strings') && g:haskell_multiline_strings
+  if a:multiline_strings
     syntax match hsLineContinuation
       \ "\%(\\$\|^\s*\\\)"
       \ contained

--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -143,21 +143,23 @@ function! vim2hs#haskell#syntax#strings() " {{{
     \ contains=hsSpecialChar,hsSpecialCharError
 
   if exists('g:haskell_multiline_strings') && g:haskell_multiline_strings
-      syntax match hsLineContinuation
-        \ "\%(\\$\|^\s*\\\)"
-        \ contained
+    syntax match hsLineContinuation
+      \ "\%(\\$\|^\s*\\\)"
+      \ contained
 
-      syntax region hsString
-        \ start=+"+ skip=+\\\\\|\\"+ end=+"+
-        \ contains=hsSpecialChar,@Spell,hsLineContinuation
+    syntax region hsString
+      \ start=+"+ skip=+\\\\\|\\"+ end=+"+
+      \ contains=hsSpecialChar,@Spell,hsLineContinuation
+
   else
-      syntax region hsStringError
-        \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
-        \ contains=hsSpecialChar,@Spell
+    syntax region hsStringError
+      \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
+      \ contains=hsSpecialChar,@Spell
 
-      syntax region hsString
-        \ start=+"+ skip=+\\\\\|\\"+ end=+"+
-        \ oneline contains=hsSpecialChar,@Spell
+    syntax region hsString
+      \ start=+"+ skip=+\\\\\|\\"+ end=+"+
+      \ oneline contains=hsSpecialChar,@Spell
+
   endif
 
   highlight! link hsSpecialChar SpecialChar

--- a/syntax/haskell.vim
+++ b/syntax/haskell.vim
@@ -19,6 +19,7 @@ call vim2hs#letdefault('g:haskell_conceal_comments'     , 0)
 call vim2hs#letdefault('g:haskell_conceal_enumerations' , 1)
 call vim2hs#letdefault('g:haskell_conceal_wide'         , 0)
 call vim2hs#letdefault('g:haskell_conceal_bad'          , 0)
+call vim2hs#letdefault('g:haskell_multiline_strings'    , 0)
 
 
 call vim2hs#haskell#syntax#operators()
@@ -98,7 +99,8 @@ call vim2hs#haskell#syntax#types()
 
 call vim2hs#haskell#syntax#folds()
 
-call vim2hs#haskell#syntax#strings()
+call vim2hs#haskell#syntax#strings(
+  \ g:haskell_multiline_strings)
 
 call vim2hs#haskell#syntax#comments(
   \ g:haskell_conceal && g:haskell_conceal_comments,


### PR DESCRIPTION
This is a first pass at adding support for multiline strings, something I definitely need for browsing the HaskellNet package.

I assume you may want to handle the variable g:haskell_multiline_strings slightly differently. And then, of course, there's the documentation and testing situation. Docs I can handle - not sure how you'd want to do testing.

Let me know about the variable and testing and I'll add commits as necessary. (I'll add a doc patch in the next couple minutes.)
