### PR TITLE
Basic support for UnicodeSyntax.

### DIFF
--- a/autoload/vim2hs/haskell/editing.vim
+++ b/autoload/vim2hs/haskell/editing.vim
@@ -123,8 +123,8 @@ function! vim2hs#haskell#editing#tabular() " {{{
   AddTabularPattern! colon                  /^[^:]*\zs:/
   AddTabularPattern! haskell_bindings       /^[^=]*\zs=\ze[^[:punct:]]/
   AddTabularPattern! haskell_comments       /--.*/l2
-  AddTabularPattern! haskell_do_arrows      / <- /l0r0
+  AddTabularPattern! haskell_do_arrows      / \(<-\|←\) /l0r0
   AddTabularPattern! haskell_imports        /^[^(]*\zs(.*\|\<as\>.*/
-  AddTabularPattern! haskell_pattern_arrows / -> /l0r0
-  AddTabularPattern! haskell_types          / :: /l0r0
+  AddTabularPattern! haskell_pattern_arrows / \(->\|→\) /l0r0
+  AddTabularPattern! haskell_types          / \(::\|∷\) /l0r0
 endfunction " }}}

--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -51,13 +51,13 @@ function! vim2hs#haskell#syntax#keywords(conceal_wide, conceal_enumerations, con
 
   if !a:conceal_wide
     syntax match hsStructure
-      \ "[[:punct:]]\@<!\%(->\|<-\|::\)[[:punct:]]\@!"
+      \ "[[:punct:]]\@<!\%(->\|→\|<-\|←\|::\|∷\)[[:punct:]]\@!"
       \ display
   endif
 
   if !a:conceal_bad
     syntax match hsStructure
-      \ "[[:punct:]]\@<!\%(=>\|-<<\?\)[[:punct:]]\@!"
+      \ "[[:punct:]]\@<!\%(=>\|⇒\|-<<\?\)[[:punct:]]\@!"
       \ display
   endif
 
@@ -85,7 +85,7 @@ endfunction " }}}
 
 function! vim2hs#haskell#syntax#types() " {{{
   syntax match hsType
-    \ "^\(\s*\)\%(default\s\+\)\?\%(\k\+\|([^[:alnum:]]\+)\)\_s*::.*\%(\n\1\s.*\)*"
+    \ "^\(\s*\)\%(default\s\+\)\?\%(\k\+\|([^[:alnum:]]\+)\)\_s*\(::\|∷\).*\%(\n\1\s.*\)*"
     \ contains=TOP,@Spell
 
   highlight! link hsType Type


### PR DESCRIPTION
Just made the syntax highlighting work. I also noticed that "::" is concealed to a wrong character in `conceal.vim` (0x2982 instead of 0x2237), you might want to fix that.
