### PR TITLE
Multi-line strings + errors

### DIFF
--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -142,20 +142,16 @@ function! vim2hs#haskell#syntax#strings(multiline_strings) " {{{
     \ "^'\%([^\\]\|\\[^']\+\|\\'\)'"
     \ contains=hsSpecialChar,hsSpecialCharError
 
+  syntax region hsStringError
+    \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
+    \ contains=hsSpecialChar,@Spell
+
   if a:multiline_strings
-    syntax match hsLineContinuation
-      \ "\%(\\$\|^\s*\\\)"
-      \ contained
-
-    syntax region hsString
-      \ start=+"+ skip=+\\\\\|\\"+ end=+"+
-      \ contains=hsSpecialChar,@Spell,hsLineContinuation
-
-  else
-    syntax region hsStringError
-      \ start=+"+ skip=+\\\\\|\\"+ end=+"\@!$+
+    syntax match hsString
+      \ /\v"(\\\_s*\\|\\[^\\]|[^\\"])*"/
       \ contains=hsSpecialChar,@Spell
 
+  else
     syntax region hsString
       \ start=+"+ skip=+\\\\\|\\"+ end=+"+
       \ oneline contains=hsSpecialChar,@Spell


### PR DESCRIPTION
I think I've found a way to match both multi-line strings _and_ strings without a closing quote. It seems to work in the few tests I could think of, but I've left it underneath the option for now, in case people want to use the simpler heuristic.
