### PR TITLE
Changed concealing of elem and notElem to their infix form

### DIFF
--- a/autoload/vim2hs/haskell/conceal.vim
+++ b/autoload/vim2hs/haskell/conceal.vim
@@ -82,11 +82,11 @@ endfunction " }}}
 " These work badly in GVIM with the fonts I've tested.
 function! vim2hs#haskell#conceal#bad() " {{{
   syntax match hsKeyword
-    \ "\<elem\>"
+    \ "`elem`"
     \ display conceal cchar=∈
 
   syntax match hsKeyword
-    \ "\<notElem\>"
+    \ "`notElem`"
     \ display conceal cchar=∉
 
   syntax match hsStructure


### PR DESCRIPTION
``elem`` and ``notElem`` seem intuitively right to be replaced

Previous form was especially misleading when used as section `(elem a)` would become `∈ a` which is not very correct looking.

![infix_elem](https://cloud.githubusercontent.com/assets/5804169/3004412/d22ac02c-dd99-11e3-8c09-c695c4a28ad3.png)
.
