### PR TITLE
HPaste for python3 enabled vim

### DIFF
--- a/autoload/vim2hs/hpaste.py3
+++ b/autoload/vim2hs/hpaste.py3
@@ -1,0 +1,31 @@
+def hpaste():
+    import vim, sys, urllib.request, urllib.parse, urllib.error
+
+    code = vim.eval('l:code')
+
+    title = vim.eval('input("Title: ")')
+    if not title:
+        print('aborted')
+        return
+
+    author = vim.eval('s:GetHPasteAuthor()')
+    language = vim.eval('&filetype')
+    channel = vim.eval('input("Channel: ")')
+
+    data = urllib.parse.urlencode({
+        'title'    : title,
+        'author'   : author,
+        'language' : language,
+        'channel'  : channel,
+        'paste'    : code,
+        'email'    : ''
+    })
+
+    try:
+        res = urllib.request.urlopen('http://lpaste.net/new', data.encode())
+        paste = res.geturl()
+        print(res.info())
+        print('Created new paste {!s}'.format(paste))
+        vim.command('call setreg("+", {!r})'.format(paste))
+    finally:
+        res.close()

--- a/autoload/vim2hs/hpaste.vim
+++ b/autoload/vim2hs/hpaste.vim
@@ -1,5 +1,7 @@
-if has('python')
+if has('python') 
   pyfile <sfile>:p:h/hpaste.py
+elseif has('python3') 
+  py3file <sfile>:p:h/hpaste3.py
 endif
 
 function! s:GetHPasteAuthor() " {{{
@@ -13,6 +15,11 @@ endfunction " }}}
 
 function! vim2hs#hpaste#hpaste(line1, line2) " {{{
   let l:code = join(getline(a:line1, a:line2), "\n")
-  python hpaste()
+  if has('python')
+    python hpaste()
+  elseif has('python3')
+    python3 hpaste()
+  endif
+  
 endfunction " }}}
 

--- a/autoload/vim2hs/hpaste.vim
+++ b/autoload/vim2hs/hpaste.vim
@@ -1,7 +1,7 @@
 if has('python') 
   pyfile <sfile>:p:h/hpaste.py
 elseif has('python3') 
-  py3file <sfile>:p:h/hpaste3.py
+  py3file <sfile>:p:h/hpaste.py3
 endif
 
 function! s:GetHPasteAuthor() " {{{

--- a/plugin/hpaste.vim
+++ b/plugin/hpaste.vim
@@ -1,4 +1,4 @@
-if has('python')
+if has('python') || has('python3')
   command! -range=% LPaste call vim2hs#hpaste#hpaste(<line1>, <line2>)
   command! -range=% HPaste call vim2hs#hpaste#hpaste(<line1>, <line2>)
 endif


### PR DESCRIPTION
My vim has python3 enabled instead of python. So I changed the existing HPaste slightly to allow for python3 as well as python.
It required a different hpaste.py but the .vim files required little change.
