### PR TITLE
Allow opting out of folding with global variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ let g:haskell_shqq          = 0
 let g:haskell_sql           = 0
 let g:haskell_json          = 0
 let g:haskell_xml           = 0
+let g:haskell_fold          = 0
 ```
 
 ### HSP & Heist

--- a/ftplugin/haskell.vim
+++ b/ftplugin/haskell.vim
@@ -2,7 +2,9 @@ call vim2hs#haskell#editing#includes()
 call vim2hs#haskell#editing#keywords()
 call vim2hs#haskell#editing#formatting()
 
-call vim2hs#haskell#editing#folding()
+if get(g:, 'haskell_fold', 1) == 1
+    call vim2hs#haskell#editing#folding()
+endif
 
 if executable('hlint')
   command! -buffer -nargs=* HLint call vim2hs#with_compiler('hlint', <q-args>)


### PR DESCRIPTION
vim2hs folds code by default. This change preserves that default, but allows adding `g:haskell_fold = 0` to your .vimrc (or similar) to opt out of folding by default on .hs file load.
