### PR TITLE
Add highlighting for identifiers in nested scope

### DIFF
--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -114,7 +114,11 @@ function! vim2hs#haskell#syntax#bindings() " {{{
   syntax match hsIdentifier
     \ "^\k\+\ze.*\%(\n\s.*\|\n\)*[[:punct:]]\@<!=[[:punct:]]\@!"
 
+  syntax match hsIdentifierNested
+    \ "^\s\+\k\+\ze.*\%(\n\s\+|.*\|\n\s*\)*\([[:punct:]]\+\|{[^}]*\)\@<!=[[:punct:]]\@!"
+
   highlight default link hsIdentifier Identifier
+  highlight default link hsIdentifierNested Identifier
 endfunction " }}}
 
 


### PR DESCRIPTION
Defined `hsIdentifierNested` syntax highlighting item for identifiers
defined in `where` clause. It matches identifier preceded by whitespaces
when it is followed by = on the same line or the next line starting with
whitespace preceded |. The = is not considered when it is within {} to
handle syntax like:

```
    Foo {foo = bar} <- action
```

or

```
    foo (\x -> x {foo = bar})
```

By default `hsIdentifierNested` is highlighted as `Identifier` but it is
a distinct item from `hsIdentifier` to allow not highlighting it or
using a different color than for top level identifiers.
