### PR TITLE
updated hsType syntax matching in syntax.vim

### DIFF
--- a/autoload/vim2hs/haskell/syntax.vim
+++ b/autoload/vim2hs/haskell/syntax.vim
@@ -103,7 +103,7 @@ endfunction " }}}
 
 function! vim2hs#haskell#syntax#types() " {{{
   syntax match hsType
-    \ "^\(\s*\)\%(default\s\+\)\?\%(\k\+\|([^[:alnum:]]\+)\)\_s*\(::\|∷\).*\%(\n\1\s.*\)*"
+    \ "^\(\s*\)\%(default\s\+\)\?\%(\k\+\|([^[:alnum:]]\+)\)'*\_s*\(::\|∷\).*\%(\n\1\s.*\)*"
     \ contains=TOP,@Spell
 
   highlight default link hsType Type


### PR DESCRIPTION
- added matching for type signatures that end with ticks
  e.g. b' :: a -> a
- fixes #92
